### PR TITLE
Feature/license boilerplate

### DIFF
--- a/apply_license.sh
+++ b/apply_license.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+license_template="license_boilerplate"
+search_string="$(head -1 ${license_template})"
+
+count=0
+for file in $(find -name *.py); do
+    if ! grep -q "${search_string}" $file; then
+        echo Applying license to ${file}
+        cat $license_template $file > tmp && mv tmp $file
+        ((count++))
+    fi
+done
+
+printf "=License applied to %i files=\n" "$count"

--- a/license_boilerplate
+++ b/license_boilerplate
@@ -1,0 +1,13 @@
+# Copyright 2017 Taylor DeHaan
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
### Overview ###
This branch adds a license boilerplate file and a simple bash script for applying the boiler plat to all Python files.

### How to Test ###
1. Add a new Python file
2. Do `./apply_license.sh`
3. You should see a printout from the script indicating it applied the license to the new file
4. Open file and confirm that the license boiler plate has been added to the file
5. Python files that already had the boilerplate should be untouched