### PR TITLE
Handle permission denied

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,12 @@ python:
   - "3.5"
   - "3.6"
   - "3.6-dev"
-  - "3.7-dev"
 
 install: "pip install -r requirements.txt"
 
 script:
   - py.test
   - pylint dir_ascii
-  
+
 notifications:
   email: false

--- a/dir_ascii/directory_explorer.py
+++ b/dir_ascii/directory_explorer.py
@@ -177,7 +177,11 @@ class DirectoryExplorer(object):
 
             # Use os.listdir to get a list of all files & directories inside of
             # the current_dir
-            listdir_result = os.listdir(current_dir)
+            try:
+                listdir_result = os.listdir(current_dir)
+            except OSError:
+                # We don't have permission to read this directory so move on
+                continue
 
             # Sort and filter the results from listdir
             files, directories = self._sort_and_filter(listdir_result,

--- a/dir_ascii/directory_explorer.py
+++ b/dir_ascii/directory_explorer.py
@@ -121,7 +121,11 @@ class DirectoryExplorer(object):
 
             # Use os.listdir to get a list of all files & directories inside of
             # the current_dir
-            listdir_result = os.listdir(current_dir)
+            try:
+                listdir_result = os.listdir(current_dir)
+            except OSError:
+                # We don't have permission to read this directory so move on
+                continue
 
             # Sort and filter the results from listdir
             files, directories = self._sort_and_filter(listdir_result,


### PR DESCRIPTION
## Overview ##
This branch adds handling for errno 13 permission denied by wrapping `os.listdir()` with a try/except clause.

This resolves #21.

## How to Test ##
Run dir-ascii on a directory you do not have permission to read.